### PR TITLE
Bug fix in maxvector

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: KRLS2
 Type: Package
 Title: Kernel-based Regularized Least squares
-Version: 1.1.0
+Version: 1.1.1
 Date: 2018-02-08
 Author: Jens Hainmueller (Stanford) Chad Hazlett (UCLA) Luke Sonnet (UCLA)
 Maintainer: Jens Hainmueller <jhain@stanford.edu>
@@ -20,4 +20,4 @@ Suggests:
     testthat,
     lattice
 URL: https://www.r-project.org, https://www.stanford.edu/~jhain/
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,14 +3,14 @@ Type: Package
 Title: Kernel-based Regularized Least squares
 Version: 1.1.1
 Date: 2018-02-08
-Author: Jens Hainmueller (Stanford) Chad Hazlett (UCLA) Luke Sonnet (UCLA)
-Maintainer: Jens Hainmueller <jhain@stanford.edu>
-Description: Implements Kernel-based Regularized Least Squares (KRLS), a
+Author: Jens Hainmueller (Stanford) Chad Hazlett (UCLA) Luke Sonnet (UCLA) (forked by Xinkun Nie with minor changes)
+Maintainer: Jens Hainmueller <jhain@stanford.edu> 
+Description: Note: this version of the package is forked by Xinkun Nie with minor fixes to the original packages. Implements Kernel-based Regularized Least Squares (KRLS), a
     machine learning method to fit multidimensional functions y=f(x) for regression
     and classification problems without relying on linearity or additivity
     assumptions. KRLS finds the best fitting function by minimizing the squared loss
     of a Tikhonov regularization problem, using Gaussian kernels as radial basis
-    functions. For further details see Hainmueller and Hazlett (2014).
+    functions. For further details see Hainmueller and Hazlett (2014). 
 Imports:
     Rcpp (>= 0.12.5),
     RSpectra

--- a/R/kernels.R
+++ b/R/kernels.R
@@ -75,7 +75,7 @@ Ktrunc <- function(X=NULL,
                         control$d,
                         nrow(K))
     
-    if (maxvector <= 500) {
+    if (maxvector <= 1000) {
       numvectorss <- maxvector
     } else {
       numvectorss <- c(250, 500, 1000, min(c(maxvector, 2000)), maxvector)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # KRLS
 [![Travis-CI Build Status](https://travis-ci.org/lukesonnet/KRLS.svg?branch=master)](https://travis-ci.org/lukesonnet/KRLS) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/lukesonnet/KRLS?branch=master&svg=true)](https://ci.appveyor.com/project/lukesonnet/KRLS) [![Coverage Status](https://coveralls.io/repos/github/lukesonnet/KRLS/badge.svg?branch=master)](https://coveralls.io/github/lukesonnet/KRLS?branch=master)
 
-This package provides methods for fitting flexible functional forms for continuous and binary outcomes. This package is under development and may behave unexpectedly. It is intended to replace the KRLS package available on CRAN. Please email [Luke Sonnet](mailto:luke.sonnet@gmail.com) or leave an issue for Luke Sonnet or Chad Hazlett.
+Note: this is a package forked from the original KRLS2 package, edited with minor fixes by Xinkun Nie. The version number has been updated to 1.1.1. 
+This package provides methods for fitting flexible functional forms for continuous and binary outcomes. 
 
 ### Install latest version
 
 You can install the latest version by running:
 ```R
-devtools::install_github('lukesonnet/KRLS')
+devtools::install_github('xnie/KRLS')
 ```
 
 ### Troubleshooting installation
@@ -17,7 +18,7 @@ This version uses `Rcpp` extensively for speed reasons. These means you need to 
 #### Windows
 If you are on Windows, you will need to install [RTools](https://cran.r-project.org/bin/windows/Rtools/) if you haven't already. If you still are having difficulty with installing and it says that the compilation failed, try installing it without support for multiple architectures:
 ```R
-devtools::install_github('lukesonnet/KRLS', args=c('--no-multiarch'))
+devtools::install_github('xnie/KRLS', args=c('--no-multiarch'))
 ```
 
 #### Mac OSX

--- a/man/krls.Rd
+++ b/man/krls.Rd
@@ -8,9 +8,9 @@ krls(X, y, w = NULL, loss = "leastsquares", whichkernel = "gaussian",
   b = NULL, bstart = NULL, binterval = c(10^-8, 500 * ncol(X)),
   lambda = NULL, hyperfolds = 5, lambdastart = 10^(-6)/length(y),
   lambdainterval = c(10^-8, 25), L = NULL, U = NULL, tol = NULL,
-  truncate = FALSE, epsilon = NULL, lastkeeper = NULL, con = list(maxit
-  = 500), returnopt = FALSE, printlevel = 0, warn = 1, sigma = NULL,
-  ...)
+  truncate = FALSE, epsilon = NULL, lastkeeper = NULL,
+  con = list(maxit = 500), returnopt = FALSE, printlevel = 0,
+  warn = 1, sigma = NULL, ...)
 }
 \arguments{
 \item{X}{\emph{N} by \emph{D} data numeric matrix that contains the values of \emph{D} predictor variables for \eqn{i=1,\ldots,N} observations. The matrix may not contain missing values or constants. Note that no intercept is required for the least squares or logistic loss. In the case of least squares, the function operates on demeaned data and subtracting the mean of \emph{y} is equivalent to including an (unpenalized) intercept into the model. In the case of logistic loss, we automatically estimate an unpenalized intercept in the linear component of the model.}

--- a/man/plot.krls2.Rd
+++ b/man/plot.krls2.Rd
@@ -6,8 +6,8 @@
 \usage{
 \method{plot}{krls2}(x, which = c(1:2),
   main = "distributions of pointwise marginal effects", setx = "mean",
-  ask = prod(par("mfcol")) < nplots, nvalues = 50, probs = c(0.25, 0.75),
-  ...)
+  ask = prod(par("mfcol")) < nplots, nvalues = 50, probs = c(0.25,
+  0.75), ...)
 }
 \arguments{
 \item{x}{an object of class \code{krls2} that preferably results from a call to 


### PR DESCRIPTION
In kernels.R, if maxvector = 800, numvectorss <- c(250, 500, 1000, min(c(maxvector, 2000)), maxvector) would return c(250, 500, 1000, 800, 800), but then 1000 > 800 and the code would throw a bug. e.g. numbervectorss can't be greater than maxvector. 

A quick fix is to make the if condition thresholding at 1000, instead of 500